### PR TITLE
Referenced Token CWT example

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -802,6 +802,7 @@ for their valuable contributions, discussions and feedback to this specification
 
 -03
 
+* change cwt referenced token example to hex and annotated hex
 * clarify the sub claim of Status List Token
 * relax status_list iss requirements for CWT
 * Fixes missing parts & iana ttl registration in CWT examples

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -220,13 +220,13 @@ This section defines the structure for a CBOR-encoded Status List:
   * `bits`: REQUIRED. Unsigned int (Major Type 0) that contains the number of bits per Referenced Token in the Status List. The allowed values for `bits` are 1, 2, 4 and 8.
   * `lst`: REQUIRED. Byte string (Major Type 2) that contains the Status List as specified in [](#status-list-json).
 
-The following example illustrates the CBOR representation of the Status List:
+The following example illustrates the CBOR representation of the Status List in Hex:
 
 ~~~~~~~~~~
 {::include ./examples/status_list_encoding_cbor}
 ~~~~~~~~~~
 
-The following is the CBOR diagnostic output of the example above:
+The following is the CBOR Annotated Hex output of the example above:
 
 ~~~~~~~~~~
 {::include ./examples/status_list_encoding_cbor_diag}
@@ -298,13 +298,13 @@ The following additional rules apply:
 
 4. Application of additional restrictions and policy are at the discretion of the verifying party.
 
-The following is a non-normative example for a Status List Token in CWT format (not including the type header yet):
+The following is a non-normative example for a Status List Token in CWT format in Hex:
 
 ~~~~~~~~~~
 {::include ./examples/status_list_cwt}
 ~~~~~~~~~~
 
-The following is the CBOR diagnostic output of the example above:
+The following is the CBOR Annotated Hex output of the example above:
 
 ~~~~~~~~~~
 {::include ./examples/status_list_cwt_diag}
@@ -364,31 +364,18 @@ The following content applies to the CWT Claims Set:
 
 Application of additional restrictions and policy are at the discretion of the verifying party.
 
-The following is a non-normative example for a decoded payload of a Referenced Token:
+The following is a non-normative example of a Referenced Token in CWT format in Hex:
 
-~~~ ascii-art
+~~~~~~~~~~
+{::include ./examples/referenced_token_cwt}
+~~~~~~~~~~
 
-18(
-    [
-      / protected / << {
-        / alg / 1: -7 / ES256 /
-      } >>,
-      / unprotected / {
-        / kid / 4: h'3132' / '13' /
-      },
-      / payload / << {
-        / iss    / 1: "https://example.com",
-        / status / 65535: {
-          "status_list": {
-            "idx": 0,
-            "uri": "https://example.com/statuslists/1"
-          }
-        }
-      } >>,
-      / signature / h'...'
-    ]
-  )
-~~~
+The following is the CBOR Annotated Hex output of the example above:
+
+~~~~~~~~~~
+{::include ./examples/referenced_token_cwt_diag}
+~~~~~~~~~~
+
 
 ## Referenced Token in other COSE/CBOR Format {#referenced-token-cose}
 

--- a/src/main.py
+++ b/src/main.py
@@ -54,24 +54,22 @@ def statusListEncoding1Bit():
     status_list = exampleStatusList1Bit()
     encoded = status_list.encodeAsJSON()
     text = "byte_array = [{}, {}] \nencoded:\n{}".format(
-        hex(status_list.list[0]),
-        hex(status_list.list[1]),
-        util.printObject(encoded)
+        hex(status_list.list[0]), hex(status_list.list[1]), util.printObject(encoded)
     )
     util.outputFile(folder + "status_list_encoding_json", text)
+
 
 def statusListEncoding1BitCBOR():
     status_list = exampleStatusList1Bit()
     encoded = status_list.encodeAsCBOR()
     hex_encoded = encoded.hex()
     text = "byte_array = [{}, {}] \nencoded:\n{}".format(
-        hex(status_list.list[0]),
-        hex(status_list.list[1]),
-        util.printText(hex_encoded)
+        hex(status_list.list[0]), hex(status_list.list[1]), util.printText(hex_encoded)
     )
     util.outputFile(folder + "status_list_encoding_cbor", text)
     diag = util.printCBORDiagnostics(encoded)
     util.outputFile(folder + "status_list_encoding_cbor_diag", diag)
+
 
 def statusListEncoding2Bit():
     status_list = exampleStatusList2Bit()
@@ -83,6 +81,7 @@ def statusListEncoding2Bit():
         util.printObject(encoded),
     )
     util.outputFile(folder + "status_list_encoding2_json", text)
+
 
 def statusListEncoding2BitCBOR():
     status_list = exampleStatusList2Bit()
@@ -98,6 +97,7 @@ def statusListEncoding2BitCBOR():
     diag = util.printCBORDiagnostics(encoded)
     util.outputFile(folder + "status_list_encoding2_cbor_diag", diag)
 
+
 def statusListJWT():
     status_list = exampleStatusList1Bit()
     jwt = StatusListToken(
@@ -109,6 +109,7 @@ def statusListJWT():
     status_jwt = jwt.buildJWT(iat=iat, exp=exp, ttl=ttl)
     text = util.formatToken(status_jwt, key)
     util.outputFile(folder + "status_list_jwt", text)
+
 
 def statusListCWT():
     status_list = exampleStatusList1Bit()
@@ -122,19 +123,19 @@ def statusListCWT():
     status_cwt = cwt.buildCWT(iat=iat, exp=exp, ttl=ttl)
     hex_encoded = status_cwt.hex()
     util.outputFile(folder + "status_list_cwt", util.printText(hex_encoded))
-    util.outputFile(folder + "status_list_cwt_diag", util.printCBORDiagnostics(status_cwt))
+    util.outputFile(
+        folder + "status_list_cwt_diag", util.printCBORDiagnostics(status_cwt)
+    )
+
 
 def referencedTokenCWT():
-    encoded = CWT(
-        iat=iat,
-        exp=exp,
-        sub="12345",
-        iss="https://example.com",
-        jwk=key
-    )
+    encoded = CWT(iat=iat, exp=exp, sub="12345", iss="https://example.com", jwk=key)
     hex_encoded = encoded.hex()
     util.outputFile(folder + "referenced_token_cwt", util.printText(hex_encoded))
-    util.outputFile(folder + "referenced_token_cwt_diag", util.printCBORDiagnostics(encoded))
+    util.outputFile(
+        folder + "referenced_token_cwt_diag", util.printCBORDiagnostics(encoded)
+    )
+
 
 if __name__ == "__main__":
     if not os.path.exists(folder):
@@ -146,4 +147,3 @@ if __name__ == "__main__":
     statusListEncoding2BitCBOR()
     statusListCWT()
     referencedTokenCWT()
-

--- a/src/main.py
+++ b/src/main.py
@@ -129,7 +129,15 @@ def statusListCWT():
 
 
 def referencedTokenCWT():
-    encoded = CWT(iat=iat, exp=exp, sub="12345", iss="https://example.com", jwk=key)
+    encoded = CWT(
+        iat=iat,
+        exp=exp,
+        sub="12345",
+        iss="https://example.com",
+        jwk=key,
+        status_url="https://example.com/statuslists/1",
+        status_idx=0,
+    )
     hex_encoded = encoded.hex()
     util.outputFile(folder + "referenced_token_cwt", util.printText(hex_encoded))
     util.outputFile(

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 from status_list import StatusList
 from status_token import StatusListToken
+from referenced_token import CWT
 from datetime import datetime, timedelta, timezone
 import os
 import util
@@ -123,6 +124,18 @@ def statusListCWT():
     util.outputFile(folder + "status_list_cwt", util.printText(hex_encoded))
     util.outputFile(folder + "status_list_cwt_diag", util.printCBORDiagnostics(status_cwt))
 
+def referencedTokenCWT():
+    encoded = CWT(
+        iat=iat,
+        exp=exp,
+        sub="12345",
+        iss="https://example.com",
+        jwk=key
+    )
+    hex_encoded = encoded.hex()
+    util.outputFile(folder + "referenced_token_cwt", util.printText(hex_encoded))
+    util.outputFile(folder + "referenced_token_cwt_diag", util.printCBORDiagnostics(encoded))
+
 if __name__ == "__main__":
     if not os.path.exists(folder):
         os.makedirs(folder)
@@ -132,3 +145,5 @@ if __name__ == "__main__":
     statusListEncoding1BitCBOR()
     statusListEncoding2BitCBOR()
     statusListCWT()
+    referencedTokenCWT()
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,11 @@
 from status_list import StatusList
 from status_token import StatusListToken
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import util
 
 key = util.EXAMPLE_KEY
-iat = datetime.utcfromtimestamp(1686920170)
+iat = datetime.fromtimestamp(1686920170, timezone.utc)
 exp = iat + timedelta(days=7000)
 ttl = timedelta(hours=12)
 folder = "./examples/"

--- a/src/referenced_token.py
+++ b/src/referenced_token.py
@@ -4,13 +4,28 @@ from datetime import datetime
 from jwcrypto import jwk
 
 
-def CWT(jwk: jwk.JWK, iat: datetime, sub: str, iss: str, exp: datetime = None):
+def CWT(
+    jwk: jwk.JWK,
+    iat: datetime,
+    sub: str,
+    iss: str,
+    status_url: str,
+    status_idx: int,
+    exp: datetime = None,
+):
     claims = {}
     claims[CWTClaims.SUB] = sub
     claims[CWTClaims.ISS] = iss
     claims[CWTClaims.IAT] = int(iat.timestamp())
     if exp is not None:
         claims[CWTClaims.EXP] = int(exp.timestamp())
+
+    claims[65535] = {
+        "status_list": {
+            "idx": status_idx,
+            "uri": status_url,
+        }
+    }
 
     protected_header = {}
     unprotected_header = {}

--- a/src/referenced_token.py
+++ b/src/referenced_token.py
@@ -1,0 +1,29 @@
+from cbor2 import dumps
+from cwt import COSE, COSEHeaders, COSEKey, CWTClaims, COSEAlgs
+from datetime import datetime
+from jwcrypto import jwk
+
+
+def CWT(jwk: jwk.JWK, iat: datetime, sub: str, iss: str, exp: datetime = None):
+    claims = {}
+    claims[CWTClaims.SUB] = sub
+    claims[CWTClaims.ISS] = iss
+    claims[CWTClaims.IAT] = int(iat.timestamp())
+    if exp is not None:
+        claims[CWTClaims.EXP] = int(exp.timestamp())
+
+    protected_header = {}
+    unprotected_header = {}
+
+    if jwk.key_id:
+        unprotected_header[COSEHeaders.KID] = jwk.key_id.encode("utf-8")
+    protected_header[COSEHeaders.ALG] = COSEAlgs.ES256
+
+    key = COSEKey.from_jwk(jwk)
+
+    sender = COSE.new()
+    encoded = sender.encode(
+        dumps(claims), key, protected=protected_header, unprotected=unprotected_header
+    )
+
+    return encoded

--- a/src/status_list.py
+++ b/src/status_list.py
@@ -62,9 +62,7 @@ class StatusList:
         rest = pos % self.divisor
         floored = pos // self.divisor
         shift = rest * self.bits
-        return (
-            self.list[floored] & (((1 << self.bits) - 1) << shift)
-        ) >> shift
+        return (self.list[floored] & (((1 << self.bits) - 1) << shift)) >> shift
 
     def __str__(self):
         val = ""

--- a/src/status_token.py
+++ b/src/status_token.py
@@ -82,7 +82,7 @@ class StatusListToken:
         ttl: timedelta = None,
         optional_claims: Dict = None,
         optional_header: Dict = None,
-        compact=True
+        compact=True,
     ) -> str:
         # build claims
         if optional_claims is not None:
@@ -111,7 +111,7 @@ class StatusListToken:
         token = jwt.JWT(header=header, claims=claims)
         token.make_signed_token(self._key)
         return token.serialize(compact=compact)
-    
+
     def buildCWT(
         self,
         iat: datetime = datetime.utcnow(),
@@ -119,7 +119,7 @@ class StatusListToken:
         ttl: timedelta = None,
         optional_claims: Dict = None,
         optional_protected_header: Dict = None,
-        optional_unprotected_header: Dict = None
+        optional_unprotected_header: Dict = None,
     ) -> bytes:
         # build claims
         if optional_claims is not None:
@@ -147,7 +147,7 @@ class StatusListToken:
             unprotected_header = {}
 
         if self._key.key_id:
-            unprotected_header[COSEHeaders.KID] = self._key.key_id.encode('utf-8')
+            unprotected_header[COSEHeaders.KID] = self._key.key_id.encode("utf-8")
         protected_header[COSEHeaders.ALG] = self._alg
         protected_header[16] = STATUS_LIST_TYP_CWT
 
@@ -159,7 +159,7 @@ class StatusListToken:
             dumps(claims),
             key,
             protected=protected_header,
-            unprotected=unprotected_header
+            unprotected=unprotected_header,
         )
 
         return encoded


### PR DESCRIPTION
Changes the CWT example to a Hex and annotated Hex version instead of diagnstic.
closes: #113
Rendered version: https://drafts.oauth.net/draft-ietf-oauth-status-list/c2bo/cwt-referencedtoken/draft-ietf-oauth-status-list.html


Did you have time to check this example with your team @tplooker?