### PR TITLE
remove http caching section

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -455,10 +455,6 @@ In the case of "application/statuslist+cwt", the response MUST be of type CWT an
 
 The HTTP response SHOULD use gzip Content-Encoding as defined in {{RFC9110}}.
 
-## Caching
-
-If caching is required (e.g., to enable the use of alternative mechanisms for hosting, like Content Delivery Networks), the control of the caching mechanism SHOULD be implemented using the standard HTTP Cache-Control as defined in {{RFC9111}}.
-
 ## Validation Rules
 
 TBD
@@ -815,6 +811,7 @@ for their valuable contributions, discussions and feedback to this specification
 
 -03
 
+* remove http caching in favor of the new ttl claim
 * clarify the sub claim of Status List Token
 * relax status_list iss requirements for CWT
 * Fixes missing parts & iana ttl registration in CWT examples


### PR DESCRIPTION
removes the http caching reference as we introduced the `ttl` option.
closes #135

Rendered version: https://drafts.oauth.net/draft-ietf-oauth-status-list/c2bo/http-caching/draft-ietf-oauth-status-list.html