### PR TITLE
fix CWT status_list map encoding

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -875,6 +875,7 @@ for their valuable contributions, discussions and feedback to this specification
 
 -04
 
+* fix CWT status_list map encoding
 * add CORS considerations to the http endpoint
 * fix reference of Status List in CBOR format
 * added status_list CWT claim key assigned

--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,7 @@ def statusListEncoding1Bit():
 
 def statusListEncoding1BitCBOR():
     status_list = exampleStatusList1Bit()
-    encoded = status_list.encodeAsCBOR()
+    encoded = status_list.encodeAsCBORRaw()
     hex_encoded = encoded.hex()
     text = "byte_array = [{}, {}] \nencoded:\n{}".format(
         hex(status_list.list[0]), hex(status_list.list[1]), util.printText(hex_encoded)
@@ -85,7 +85,7 @@ def statusListEncoding2Bit():
 
 def statusListEncoding2BitCBOR():
     status_list = exampleStatusList2Bit()
-    encoded = status_list.encodeAsCBOR()
+    encoded = status_list.encodeAsCBORRaw()
     hex_encoded = encoded.hex()
     text = "byte_array = [{}, {}, {}] \nencoded:\n{}".format(
         hex(status_list.list[0]),

--- a/src/status_list.py
+++ b/src/status_list.py
@@ -43,6 +43,10 @@ class StatusList:
             "bits": self.bits,
             "lst": encoded_list,
         }
+        return object
+
+    def encodeAsCBORRaw(self) -> Dict:
+        object = self.encodeAsCBOR()
         return dumps(object)
 
     def decode(self, input: str):


### PR DESCRIPTION
`status_list` in the Status List Token in CWT form was encoded as Byte String instead of Map (type 5) as defined in the CBOR Section (4.2).

Rendered version: https://drafts.oauth.net/draft-ietf-oauth-status-list/c2bo/fix-cwt-statuslist-encoding/draft-ietf-oauth-status-list.html