### PR TITLE
fix rendering & improve IANA registration text

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -649,14 +649,14 @@ IANA "JSON Web Token Claims" registry {{IANA.JWT}} established by {{RFC7519}}.
 * Claim Name: `status`
 * Claim Description: Reference to a status or validity mechanism containing up-to-date status information on the JWT.
 * Change Controller: IETF
-* Specification Document(s):  [](#status-claim) of this specification
+* Specification Document(s): [](#status-claim) of this specification
 
 <br/>
 
 * Claim Name: `status_list`
 * Claim Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
-* Specification Document(s):  [](#status-list-token-jwt) of this specification
+* Specification Document(s): [](#status-list-token-jwt) of this specification
 
 <br/>
 
@@ -693,7 +693,7 @@ Specification Document(s):
 * Status Method Value: `status_list`
 * Status Method Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
-* Specification Document(s):  [](#referenced-token-jwt) of this specification
+* Specification Document(s): [](#referenced-token-jwt) of this specification
 
 ## CBOR Web Token Claims Registration
 
@@ -708,7 +708,7 @@ IANA "CBOR Web Token (CWT) Claims" registry {{IANA.CWT}} established by {{RFC839
 * Claim Key: TBD (requested assignment 65535)
 * Claim Description: Reference to a status or validity mechanism containing up-to-date status information on the CWT.
 * Change Controller: IETF
-* Specification Document(s):  [](#status-claim) of this specification
+* Specification Document(s): [](#status-claim) of this specification
 
 <br/>
 
@@ -716,7 +716,7 @@ IANA "CBOR Web Token (CWT) Claims" registry {{IANA.CWT}} established by {{RFC839
 * Claim Key: TBD (requested assignment 65533)
 * Claim Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
-* Specification Document(s):  [](#status-list-token-cwt) of this specification
+* Specification Document(s): [](#status-list-token-cwt) of this specification
 
 <br/>
 
@@ -753,7 +753,7 @@ Specification Document(s):
 * Status Method Value: `status_list`
 * Status Method Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
-* Specification Document(s):  [](#referenced-token-cwt) of this specification
+* Specification Document(s): [](#referenced-token-cwt) of this specification
 
 ## Media Type Registration
 
@@ -767,15 +767,13 @@ To indicate that the content is an JSON-based Status List:
   * Subtype name: statuslist+json
   * Required parameters: n/a
   * Optional parameters: n/a
-  * Encoding considerations: binary; A JSON-based Status List is a JSON Object.
-  * Security considerations: See (#Security) of \[ this specification \]
+  * Encoding considerations: See [](#status-list-json) of this specification
+  * Security considerations: See [](#Security) of this specification
   * Interoperability considerations: n/a
-  * Published specification: \[ this specification \]
-  * Applications that use this media type: Applications using \[ this specification \] for updated status information of tokens
+  * Published specification: this specification
+  * Applications that use this media type: Applications using this specification for updated status information of tokens
   * Fragment identifier considerations: n/a
-  * Additional information:
-    * File extension(s): n/a
-    * Macintosh file type code(s): n/a
+  * Additional information: n/a
   * Person &amp; email address to contact for further information: Paul Bastian, paul.bastian@posteo.de
   * Intended usage: COMMON
   * Restrictions on usage: none
@@ -789,15 +787,13 @@ To indicate that the content is an JWT-based Status List:
   * Subtype name: statuslist+jwt
   * Required parameters: n/a
   * Optional parameters: n/a
-  * Encoding considerations: binary; A JWT-based Status List is a JWT; JWT values are encoded as a series of base64url-encoded values (some of which may be the empty string) separated by period ('.') characters.
-  * Security considerations: See (#Security) of \[ this specification \]
+  * Encoding considerations: See [](#status-list-token-jwt) of this specification
+  * Security considerations: See [](#Security) of this specification
   * Interoperability considerations: n/a
-  * Published specification: \[ this specification \]
-  * Applications that use this media type: Applications using \[ this specification \] for updated status information of tokens
+  * Published specification: this specification
+  * Applications that use this media type: Applications using this specification for updated status information of tokens
   * Fragment identifier considerations: n/a
-  * Additional information:
-    * File extension(s): n/a
-    * Macintosh file type code(s): n/a
+  * Additional information: n/a
   * Person &amp; email address to contact for further information: Paul Bastian, paul.bastian@posteo.de
   * Intended usage: COMMON
   * Restrictions on usage: none
@@ -811,15 +807,13 @@ To indicate that the content is an CBOR-based Status List:
   * Subtype name: statuslist+cbor
   * Required parameters: n/a
   * Optional parameters: n/a
-  * Encoding considerations: binary; A CBOR-based Status List is a CBOR Object.
-  * Security considerations: See (#Security) of \[ this specification \]
+  * Encoding considerations: See [](#status-list-cbor) of this specification
+  * Security considerations: See [](#Security) of this specification
   * Interoperability considerations: n/a
-  * Published specification: \[ this specification \]
-  * Applications that use this media type: Applications using \[ this specification \] for updated status information of tokens
+  * Published specification: this specification
+  * Applications that use this media type: Applications using this specification for updated status information of tokens
   * Fragment identifier considerations: n/a
-  * Additional information:
-    * File extension(s): n/a
-    * Macintosh file type code(s): n/a
+  * Additional information: n/a
   * Person &amp; email address to contact for further information: Paul Bastian, paul.bastian@posteo.de
   * Intended usage: COMMON
   * Restrictions on usage: none
@@ -833,15 +827,13 @@ To indicate that the content is an CWT-based Status List:
   * Subtype name: statuslist+cwt
   * Required parameters: n/a
   * Optional parameters: n/a
-  * Encoding considerations: binary;
-  * Security considerations: See (#Security) of \[ this specification \]
+  * Encoding considerations: See [](#status-list-token-cwt) of this specification
+  * Security considerations: See [](#Security) of this specification
   * Interoperability considerations: n/a
-  * Published specification: \[ this specification \]
-  * Applications that use this media type: Applications using \[ this specification \] for updated status information of tokens
+  * Published specification: this specification
+  * Applications that use this media type: Applications using this specification for updated status information of tokens
   * Fragment identifier considerations: n/a
-  * Additional information:
-    * File extension(s): n/a
-    * Macintosh file type code(s): n/a
+  * Additional information: n/a
   * Person &amp; email address to contact for further information: Paul Bastian, paul.bastian@posteo.de
   * Intended usage: COMMON
   * Restrictions on usage: none

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -605,6 +605,7 @@ A malicious Issuer could bypass the privacy benefits of the herd privacy by gene
 Once the Relying Party receives the Referenced Token, this enables him to request the Status List to validate its status through the provided `uri` parameter and look up the corresponding `index`. However, the Relying Party may persistently store the `uri` and `index` of the Referenced Token to request the Status List again at a later time. By doing so regularly, the Relying Party may create a profile of the Referenced Token's validity status. This behaviour may be intended as a feature, e.g. for a KYC process that requires regular validity checks, but might also be abused in cases where this is not intended and unknown to the Holder, e.g. profiling the suspension of a driving license or checking the employment status of an employee credential.
 
 This behaviour could be mitigated by:
+
 - adding authorization rules to the Status List, see [](#security-authorization).
 - regular re-issuance of the Referenced Token, see [](#implementation-lifecycle).
 
@@ -653,7 +654,7 @@ IANA "JSON Web Token Claims" registry {{IANA.JWT}} established by {{RFC7519}}.
 <br/>
 
 * Claim Name: `status_list`
-* Claim Description: A status list containing up-to-date status information on multiple other JWTs encoded as a bitarray.
+* Claim Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
 * Specification Document(s):  [](#status-list-token-jwt) of this specification
 
@@ -690,7 +691,7 @@ Specification Document(s):
 ### Initial Registry Contents
 
 * Status Method Value: `status_list`
-* Status Method Description: A status list containing up-to-date status information on multiple other JWTs encoded as a bitarray.
+* Status Method Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
 * Specification Document(s):  [](#referenced-token-jwt) of this specification
 
@@ -713,7 +714,7 @@ IANA "CBOR Web Token (CWT) Claims" registry {{IANA.CWT}} established by {{RFC839
 
 * Claim Name: `status_list`
 * Claim Key: TBD (requested assignment 65533)
-* Claim Description: A status list containing up-to-date status information on multiple other CWTs encoded as a bitarray.
+* Claim Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
 * Specification Document(s):  [](#status-list-token-cwt) of this specification
 
@@ -750,7 +751,7 @@ Specification Document(s):
 ### Initial Registry Contents
 
 * Status Method Value: `status_list`
-* Status Method Description: A status list containing up-to-date status information on multiple other CWTs encoded as a bitarray.
+* Status Method Description: A status list containing up-to-date status information on multiple tokens.
 * Change Controller: IETF
 * Specification Document(s):  [](#referenced-token-cwt) of this specification
 
@@ -875,6 +876,7 @@ for their valuable contributions, discussions and feedback to this specification
 
 -04
 
+* editorial fixes
 * add CORS considerations to the http endpoint
 * fix reference of Status List in CBOR format
 * added status_list CWT claim key assigned


### PR DESCRIPTION
- fixes the list rendering (missing newline)
- clarifies IANA text to just reference other tokens

Rendered version: https://drafts.oauth.net/draft-ietf-oauth-status-list/c2bo/editiorial-fixes/draft-ietf-oauth-status-list.html 