### PR TITLE
status list token cwt example uses new claim key

### DIFF
--- a/src/status_token.py
+++ b/src/status_token.py
@@ -135,7 +135,7 @@ class StatusListToken:
             claims[CWTClaims.EXP] = int(exp.timestamp())
         if ttl is not None:
             claims[65534] = int(ttl.total_seconds())
-        claims[65535] = self.list.encodeAsCBOR()
+        claims[65533] = self.list.encodeAsCBOR()
 
         # build header
         if optional_protected_header is not None:


### PR DESCRIPTION
#160 introduced the new claim key for status_list within the status list cwt, but the example wasn't adjusted