### PR TITLE
mixing formats and media types

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -835,14 +835,13 @@ The Status List Issuer may chunk its Referenced Tokens into multiple Status List
 
 ## Status List Formats
 
- This specification defines 4 different formats that can be used to provide a status list:
+ This specification defines 4 different formats of the status list:
 
  - JSON
  - JWT
  - CBOR
  - CWT
 
-This decision was made to allow the highest degree of freedom to use the variant that best fits the ecosystem & use-case intending to add a status or validity information.
 
 This specification states no requirements to not mix different formats like a CBOR based token using a JWT for the status list, but the expectation is that within an ecosystem, a choice for specific formats is made.
 Within such an ecosystem, only support for those selected variants is required and implementations should know what to expect via a profile.

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -1079,6 +1079,11 @@ for their valuable contributions, discussions and feedback to this specification
 # Document History
 {:numbered="false"}
 
+
+-05
+
+* add section about mixing status list formats and media type
+
 -04
 
 * add mDL example as Referenced Token and consolidate CWT and CBOR sections

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -843,7 +843,7 @@ The Status List Issuer may chunk its Referenced Tokens into multiple Status List
  - CWT
 
 
-This specification states no requirements to not mix different formats like a CBOR based token using a JWT for the status list, but the expectation is that within an ecosystem, a choice for specific formats is made.
+This specification states no requirements to not mix different formats like a CBOR based Referenced Token using a JWT for the Status List, but the expectation is that within an ecosystem, a choice for specific formats is made.
 Within such an ecosystem, only support for those selected variants is required and implementations should know what to expect via a profile.
 
 The return type of a status list should be signaled by media type as described in [](#status-types-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or name extension(s) of the URI.

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -847,7 +847,7 @@ This decision was made to allow the highest degree of freedom to use the variant
 This specification states no requirements to not mix different formats like a CBOR based token using a JWT for the status list, but the expectation is that within an ecosystem, a choice for specific formats is made.
 Within such an ecosystem, only support for those selected variants is required and implementations should know what to expect via a profile.
 
-The return type of a status list should be signaled by media type as described in [](#status-types-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or via name extension(s) of the URI.
+The return type of a status list should be signaled by media type as described in [](#status-types-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or name extension(s) of the URI.
 
 # IANA Considerations
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -607,9 +607,9 @@ The Relying Party SHOULD send the following Accept-Header to indicate the reques
 
 If the Relying Party does not send an Accept Header, the response type is assumed to be known implicit or out-of-band.
 
-## Status List Response
+## Status List Response {#status-types-response}
 
-In the successful response, the Status List Provider MUST use the following content-type:
+In the successful response, the Status List Provider SHOULD use the following content-type:
 
 - "application/statuslist+json" for Status List in JSON format
 - "application/statuslist+jwt" for Status List in JWT format
@@ -832,6 +832,22 @@ Implementations producing Status Lists are RECOMMENDED to prevent double allocat
 The Status List Issuer may increase the size of a Status List if it requires indices for additional Referenced Tokens. It is RECOMMENDED that the size of a Status List in bits is divisible in bytes (8 bits) without a remainder, i.e. `size-in-bits` % 8 = 0.
 
 The Status List Issuer may chunk its Referenced Tokens into multiple Status Lists to reduce the transmission size of an individual Status List Token. This may be useful for setups where some entities operate in constrained environments, e.g. for mobile internet or embedded devices.
+
+## Status List Formats
+
+ This specification defines 4 different formats that can be used to provide a status list:
+
+ - JSON
+ - JWT
+ - CBOR
+ - CWT
+
+This decision was made to allow the highest degree of freedom to use the variant that best fits the ecosystem & use-case intending to add a status or validity information.
+
+This specification states no requirements to not mix different formats like a CBOR based token using a JWT for the status list, but the expectation is that within an ecosystem, a choice for specific formats is made.
+Within such an ecosystem, only support for those selected variants is required and implementations should know what to expect via a profile.
+
+The return type of a status list should be signaled by media type as described in [](#status-types-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or via name extension(s) of the URI.
 
 # IANA Considerations
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -1237,10 +1237,12 @@ for their valuable contributions, discussions and feedback to this specification
 # Document History
 {:numbered="false"}
 
+-06
+
+* add section about mixing status list formats and media type
 
 -05
 
-* add section about mixing status list formats and media type
 * add optional support for historical requests
 * update CBOR claim definitions
 * improve section on Status Types and introduce IANA registry for it

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -657,7 +657,7 @@ Content-Type: application/statuslist+jwt
 
 ## Status List Response {#status-list-response}
 
-In the successful response, the Status List Provider MUST use the following content-type unless known out of band:
+In the successful response, the Status List Provider MUST use the following content-type:
 
 - "application/statuslist+json" for Status List in JSON format
 - "application/statuslist+jwt" for Status List in JWT format
@@ -929,7 +929,6 @@ The Status List Issuer may chunk its Referenced Tokens into multiple Status List
 This specification states no requirements to not mix different formats like a CBOR based Referenced Token using a JWT for the Status List, but the expectation is that within an ecosystem, a choice for specific formats is made.
 Within such an ecosystem, only support for those selected variants is required and implementations should know what to expect via a profile.
 
-The return type of a status list should be signaled by media type as described in [](#status-list-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or name extension(s) of the URI.
 
 # IANA Considerations
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -657,7 +657,7 @@ Content-Type: application/statuslist+jwt
 
 ## Status List Response {#status-list-response}
 
-In the successful response, the Status List Provider SHOULD use the following content-type:
+In the successful response, the Status List Provider MUST use the following content-type unless known out of band:
 
 - "application/statuslist+json" for Status List in JSON format
 - "application/statuslist+jwt" for Status List in JWT format

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -607,7 +607,7 @@ The Relying Party SHOULD send the following Accept-Header to indicate the reques
 
 If the Relying Party does not send an Accept Header, the response type is assumed to be known implicit or out-of-band.
 
-## Status List Response {#status-types-response}
+## Status List Response {#status-list-response}
 
 In the successful response, the Status List Provider SHOULD use the following content-type:
 
@@ -846,7 +846,7 @@ The Status List Issuer may chunk its Referenced Tokens into multiple Status List
 This specification states no requirements to not mix different formats like a CBOR based Referenced Token using a JWT for the Status List, but the expectation is that within an ecosystem, a choice for specific formats is made.
 Within such an ecosystem, only support for those selected variants is required and implementations should know what to expect via a profile.
 
-The return type of a status list should be signaled by media type as described in [](#status-types-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or name extension(s) of the URI.
+The return type of a status list should be signaled by media type as described in [](#status-list-response). If no media type was provided and the expected type is not clearly defined the ecosystem, implementations should be robust to parsing errors. In that case, a client MAY attempt to guess the media type via inspection of the response or name extension(s) of the URI.
 
 # IANA Considerations
 


### PR DESCRIPTION
closes #38
closes #168
closes #137

Rendered preview: https://drafts.oauth.net/draft-ietf-oauth-status-list/c2bo/mixing-formats/draft-ietf-oauth-status-list.html

This PR attempts to add a bit of language about mixing formats and also changes the content-type in the status list response to SHOULD and language around content type parsing that is similar to the language used in HTTP/1.1.

I am happy to remove the media types part if we want a bit more discussion, but when I started writing this, it felt like right path so I decided to include it as a proposal.