### PR TITLE
chore: fix python example build for newer ubuntu versions

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -29,7 +29,7 @@ jobs:
     - name: "Generate examples"
       run: |
         npm install -g cborg
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip wheel setuptools
         python3 -m pip install -r src/requirements.txt
         python3 src/main.py
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: "Generate examples"
       run: |
         npm install -g cborg
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip wheel setuptools
         python3 -m pip install -r src/requirements.txt
         python3 src/main.py
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,6 @@
+# Fixes build problems with certain openssl versions
+git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3
+# Normal dependencies
 jwcrypto==1.5.6
 cbor2==5.6.2
 cwt==2.7.4


### PR DESCRIPTION
Github updated the ubuntu version of the runners creating problems with oscrypto - this should fix the builds for now.