### PR TITLE
fix cwt typ to use full media type

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -1795,6 +1795,10 @@ CBOR encoding:
 # Document History
 {:numbered="false"}
 
+-08
+
+ * Fix cwt typ value to full media type
+
 -07
 
 * add considerations about External Status Issuer or Status Provider

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -414,7 +414,7 @@ The Status List Token MUST be encoded as a "CBOR Web Token (CWT)" according to {
 
 The following content applies to the protected header of the CWT:
 
-* `16` (type): REQUIRED. The type of the CWT MUST be `statuslist+cwt` as defined in {{RFC9596}}.
+* `16` (type): REQUIRED. The type of the CWT MUST be `application/statuslist+cwt` as defined in {{RFC9596}}.
 
 The following content applies to the CWT Claims Set:
 

--- a/src/status_token.py
+++ b/src/status_token.py
@@ -10,7 +10,7 @@ from status_list import StatusList
 
 DEFAULT_ALG = "ES256"
 STATUS_LIST_TYP_JWT = "statuslist+jwt"
-STATUS_LIST_TYP_CWT = "statuslist+cwt"
+STATUS_LIST_TYP_CWT = "application/statuslist+cwt"
 
 
 class StatusListToken:


### PR DESCRIPTION
Closes #262 

COSE/CWT typ behaves a bit differently than JOSE/JWT typ and requires the full media type.