### PR TITLE
Add cddl for statuslist cbor encoding

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -362,7 +362,7 @@ The following is the CDDL definition of the StatusList structure:
 
 ~~~ cddl
 StatusList = {
-    bits: int, ; The amount of bits used per Referenced Token
+    bits: 1 / 2 / 4 / 8, ; The number of bits used per Referenced Token
     lst: bstr, ; Byte string that contains the Status List
     ? aggregation_uri: tstr, ; link to the Status List Aggregation
 }

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -358,6 +358,16 @@ This section defines the data structure for a CBOR-encoded Status List:
   * `lst`: REQUIRED. Byte string (Major Type 2) that contains the Status List as specified in [](#status-list).
   * `aggregation_uri`: OPTIONAL. Text string (Major Type 3) that contains a URI to retrieve the Status List Aggregation for this type of Referenced Token. See section [](#aggregation) for further detail.
 
+The following is the CDDL definition of the StatusList structure:
+
+~~~ cddl
+StatusList = {
+    bits: int, ; The amount of bits used per Referenced Token
+    lst: bstr, ; Byte string that contains the Status List
+    ? aggregation_uri: tstr, ; link to the Status List Aggregation
+}
+~~~
+
 The following example illustrates the CBOR representation of the Status List in Hex:
 
 ~~~~~~~~~~
@@ -1801,6 +1811,7 @@ CBOR encoding:
 
 -08
 
+* Add CDDL for CBOR StatusList encoding
 * Fix cwt typ value to full media type
 * Holders may also fetch and verify Status List Tokens
 * Update terminology for referenced token and Status List Token

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -1809,9 +1809,12 @@ CBOR encoding:
 # Document History
 {:numbered="false"}
 
--08
+-09
 
 * Add CDDL for CBOR StatusList encoding
+
+-08
+
 * Fix cwt typ value to full media type
 * Holders may also fetch and verify Status List Tokens
 * Update terminology for referenced token and Status List Token


### PR DESCRIPTION
Closes #267 
I only added the CDDL for the StatusList object CBOR encoding which seemed to be the most important to provide CDDL for. I don't think CDDL for the CWT would help (and I didn't find many examples in other specs doing CDDL for CWT).

@rohanmahy Would that work for you?