### PR TITLE
size comparison

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -31,7 +31,7 @@ jobs:
     - name: "Generate examples"
       run: |
         npm install -g cborg
-        python3 -m pip install --upgrade pip wheel setuptools
+        python3 -m pip install --upgrade pip wheel setuptools==76.1.0
         python3 -m pip install -r src/requirements.txt
         python3 src/main.py
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     - name: "Generate examples"
       run: |
         npm install -g cborg
-        python3 -m pip install --upgrade pip wheel setuptools
+        python3 -m pip install --upgrade pip wheel setuptools==76.1.0
         python3 -m pip install -r src/requirements.txt
         python3 src/main.py
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -844,7 +844,7 @@ An Issuer MAY support any of these mechanisms:
 - Issuer metadata: The Issuer of the Referenced Token publishes an URI which links to Status List Aggregation, e.g. in publicly available metadata of an issuance protocol
 - Status List Parameter: The Status Issuer includes an additional claim in the Status List Token that contains the Status List Aggregation URI.
 
-~~~ ascii art
+~~~ ascii-art
                                       ┌─────────────────┐
                                       │                 │
                                       │ Issuer Metadata │
@@ -1453,6 +1453,33 @@ Torsten Lodderstedt
 
 for their valuable contributions, discussions and feedback to this specification.
 
+# Size comparison {#size-comparison}
+{:unnumbered}
+
+The following tables show a size comparison for a Status List (compressed byte array) and a compressedd Byte Array of UUIDs.
+
+## Status List size for varying sizes and revocation rates
+{:unnumbered}
+
+| Size | 0.01%   | 0.1%     | 1%       | 2%       | 5%       | 10%      | 25%       | 50%      | 75%       | 100%    |
+| 100k | 81 B    | 252 B    | 1.4 KB   | 2.3 KB   | 4.5 KB   | 6.9 KB   | 10.2 KB   | 12.2 KB  | 10.2 KB   | 35 B    |
+| 1M   | 442 B   | 2.2 KB   | 13.7 KB  | 23.0 KB  | 43.9 KB  | 67.6 KB  | 102.2 KB  | 122.1 KB | 102.4 KB  | 144 B   |
+| 10M  | 3.8 KB  | 21.1 KB  | 135.4 KB | 230.0 KB | 437.0 KB | 672.9 KB | 1023.4 KB | 1.2 MB   | 1023.5 KB | 1.2 KB  |
+| 100M | 38.3 KB | 213.0 KB | 1.3 MB   | 2.2 MB   | 4.3 MB   | 6.6 MB   | 10.0 MB   | 11.9 MB  | 10.0 MB   | 11.9 KB |
+{: title="Status List Size examples for varying sizes and revocation rates"}
+
+## Compressed array of UUIDv4 (128 bit UUIDs) for varying sizes and revocation rates
+{:unnumbered}
+
+This is a simple approximation of the best case size for UUID based variants without any additional metadata (128 bit UUID per revoked entry).
+
+| Size | 0.01%    | 0.1%     | 1%       | 2%       | 5%      | 10%      | 25%      | 50%      | 75%      | 100%     |
+| 100k | 219 B    | 1.6 KB   | 15.4 KB  | 29.7 KB  | 78.1 KB | 154.9 KB | 392.9 KB | 783.1 KB | 1.1 MB   | 1.5 MB   |
+| 1M   | 1.6 KB   | 16.4 KB  | 157.7 KB | 310.4 KB | 781 KB  | 1.5 MB   | 3.8 MB   | 7.6 MB   | 11.4 MB  | 15.3 MB  |
+| 10M  | 15.3 KB  | 155.9 KB | 1.5 MB   | 3.1 MB   | 7.6 MB  | 15.2 MB  | 38.2 MB  | 76.3 MB  | 114.4 MB | 152.6 MB |
+| 100M | 157.6 KB | 1.5 MB   | 15.3 MB  | 30.5 MB  | 76.3 MB | 152.6 MB | 381.4 MB | 762.9 MB | 1.1 GB   | 1.5 GB   |
+{: title="Size examples for 128 bit UUIDs for varying sizes and revocation rates"}
+
 # Test vectors for Status List encoding {#test-vectors}
 {:unnumbered}
 
@@ -1836,6 +1863,10 @@ CBOR encoding:
 
 # Document History
 {:numbered="false"}
+
+-10
+
+* Add size comparison for status list and compressed uuids
 
 -09
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -1456,7 +1456,7 @@ for their valuable contributions, discussions and feedback to this specification
 # Size comparison {#size-comparison}
 {:unnumbered}
 
-The following tables show a size comparison for a Status List (compressed byte array) and a compressedd Byte Array of UUIDs.
+The following tables show a size comparison for a Status List (compressed byte array as defined in [](#status-list-byte-array) and a compressed Byte Array of UUIDs.
 
 ## Status List size for varying sizes and revocation rates
 {:unnumbered}

--- a/src/bench.py
+++ b/src/bench.py
@@ -1,0 +1,71 @@
+import math
+import zlib
+from random import choices
+from uuid import uuid4
+
+from py_markdown_table.markdown_table import markdown_table
+
+from status_list import StatusList
+
+
+def display_size(size_bytes):
+    if size_bytes == 0:
+        return "0B"
+    size_name = ("B", "KB", "MB", "GB")
+    floored = int(math.floor(math.log(size_bytes, 1024)))
+    p = math.pow(1024, floored)
+    rounded = round(size_bytes / p, 1)
+    return "%s %s" % (rounded, size_name[floored])
+
+
+sizes = [100000, 1000000, 10000000, 100000000]
+rev_rates = [0.0001, 0.001, 0.01, 0.02, 0.05, 0.1, 0.25, 0.5, 0.75, 1]
+
+data_sl = []
+data_uuid = []
+
+for size in sizes:
+    newdata_sl = {"size": size}
+    newdata_uuid = {"size": size}
+    for rev_rate in rev_rates:
+        print(f"Revocation Rate: {rev_rate}")
+        vals = [0, 1]
+        p = [1 - rev_rate, rev_rate]
+        sample = choices(population=vals, weights=p, k=size)
+
+        statuslist = StatusList(size, 1)
+        idlist = bytearray()
+        for idx, val in enumerate(sample):
+            statuslist.set(idx, val)
+            if val == 1:
+                idlist.extend(uuid4().bytes)
+
+        rawsl = statuslist.encodeAsBytes()
+        rawidlist = zlib.compress(idlist, level=9)
+
+        percentage = str(rev_rate * 100) + "%"
+        newdata_sl[percentage] = display_size(len(rawsl))
+        newdata_uuid[percentage] = display_size(len(rawidlist))
+        print(f"Size in Bytes: {display_size(len(rawsl))}")
+        print(f"Size in Bytes uuid: {display_size(len(rawidlist))}")
+    data_sl.append(newdata_sl)
+    data_uuid.append(newdata_uuid)
+
+markdown_sl = (
+    markdown_table(data_sl)
+    .set_params(
+        padding_width=3,
+        padding_weight="centerleft",
+    )
+    .get_markdown()
+)
+print(markdown_sl)
+markdown_uuid = (
+    markdown_table(data_uuid)
+    .set_params(
+        padding_width=3,
+        padding_weight="centerleft",
+    )
+    .get_markdown()
+)
+print(markdown_uuid)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742
 jwcrypto==1.5.6
 cbor2==5.6.2
 cwt==2.7.4
+py_markdown_table==1.3.0

--- a/src/status_list.py
+++ b/src/status_list.py
@@ -1,9 +1,11 @@
+import math
 import zlib
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from typing import Dict
 
 from cbor2 import dumps, loads
 
+LEVEL=9
 
 class StatusList:
     list: bytearray
@@ -13,7 +15,7 @@ class StatusList:
 
     def __init__(self, size: int, bits: int):
         self.divisor = 8 // bits
-        self.list = bytearray([0] * (size // self.divisor))
+        self.list = bytearray([0] * math.ceil(size / self.divisor))
         self.bits = bits
         self.size = size
 
@@ -24,11 +26,11 @@ class StatusList:
         return new
 
     def encodeAsString(self) -> str:
-        zipped = zlib.compress(self.list, level=9)
+        zipped = zlib.compress(self.list, level=LEVEL)
         return urlsafe_b64encode(zipped).decode().strip("=")
 
     def encodeAsBytes(self) -> bytes:
-        return zlib.compress(self.list, level=9)
+        return zlib.compress(self.list, level=LEVEL)
 
     def encodeAsJSON(self) -> Dict:
         encoded_list = self.encodeAsString()


### PR DESCRIPTION
Closes #276 

Rendered Version: https://drafts.oauth.net/draft-ietf-oauth-status-list/276-size-comparison/draft-ietf-oauth-status-list.html#name-size-comparison

Not really happy with  how the table renders, but there seem to be some limit to what is possible with kramdown table parsing?